### PR TITLE
Execute Popen GPU jobs with bash instead of sh

### DIFF
--- a/simple_gpu_scheduler/scheduler.py
+++ b/simple_gpu_scheduler/scheduler.py
@@ -75,7 +75,7 @@ def run_command_with_gpu(command, gpu):
     """
     myenv = os.environ.copy()
     myenv['CUDA_VISIBLE_DEVICES'] = str(gpu)
-    print(f'Processing command `{command}` on gpu {gpu}')
+    print(f'Processing /bin/bash command `{command}` on gpu {gpu}')
 
     def run_then_release_GPU(command, gpu):
         myenv = os.environ.copy()

--- a/simple_gpu_scheduler/scheduler.py
+++ b/simple_gpu_scheduler/scheduler.py
@@ -83,7 +83,8 @@ def run_command_with_gpu(command, gpu):
         proc = subprocess.Popen(
             args=command,
             shell=True,
-            env=myenv
+            env=myenv,
+            executable='/bin/bash',
         )
         proc.wait()
         gpu.release()

--- a/simple_gpu_scheduler/scheduler.py
+++ b/simple_gpu_scheduler/scheduler.py
@@ -80,6 +80,7 @@ def run_command_with_gpu(command, gpu):
     def run_then_release_GPU(command, gpu):
         myenv = os.environ.copy()
         myenv['CUDA_VISIBLE_DEVICES'] = str(gpu)
+        print("Trying bash command')
         proc = subprocess.Popen(
             args=["/bin/bash", "-i", "-c", command],
             shell=True,

--- a/simple_gpu_scheduler/scheduler.py
+++ b/simple_gpu_scheduler/scheduler.py
@@ -81,7 +81,7 @@ def run_command_with_gpu(command, gpu):
         myenv = os.environ.copy()
         myenv['CUDA_VISIBLE_DEVICES'] = str(gpu)
         proc = subprocess.Popen(
-            args=command,
+            args=["/bin/bash", "-i", "-c", command],
             shell=True,
             env=myenv,
             executable='/bin/bash',


### PR DESCRIPTION
Gives the advantage that you can use things already defined in ~/.bashrc and ~/.bash_aliases.